### PR TITLE
Add codex pages with login and admin tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
 		"": {
 			"name": "my-app",
 			"version": "0.0.1",
+			"dependencies": {
+				"idb-keyval": "^6.2.2"
+			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^6.0.0",
 				"@sveltejs/kit": "^2.22.0",
@@ -1031,6 +1034,12 @@
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
+		},
+		"node_modules/idb-keyval": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+			"integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
 		"svelte-check": "^4.0.0",
 		"typescript": "^5.0.0",
 		"vite": "^7.0.4"
+	},
+	"dependencies": {
+		"idb-keyval": "^6.2.2"
 	}
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,0 +1,49 @@
+import { get, set } from 'idb-keyval';
+
+export interface Character {
+  name: string;
+  category: string;
+  tier: string;
+}
+
+export interface Lightcone {
+  name: string;
+  rarity: string;
+}
+
+export async function getCharacters(): Promise<Character[]> {
+  return (await get<Character[]>('characters')) ?? [];
+}
+
+export async function addCharacter(c: Character) {
+  const list = await getCharacters();
+  list.push(c);
+  await set('characters', list);
+}
+
+export async function getLightcones(): Promise<Lightcone[]> {
+  return (await get<Lightcone[]>('lightcones')) ?? [];
+}
+
+export async function addLightcone(c: Lightcone) {
+  const list = await getLightcones();
+  list.push(c);
+  await set('lightcones', list);
+}
+
+export async function getTiered(): Promise<Record<string, Record<string, string[]>>> {
+  const chars = await getCharacters();
+  const categories = ['DPS', 'Support DPS', 'Amplifier', 'Sustain'];
+  const tiers = ['T0', 'T0.5', 'T1', 'T2', 'T3', 'T4', 'T5'];
+  const out: Record<string, Record<string, string[]>> = {};
+  for (const cat of categories) {
+    out[cat] = {};
+    for (const tier of tiers) out[cat][tier] = [];
+  }
+  for (const c of chars) {
+    if (!out[c.category]) out[c.category] = {};
+    if (!out[c.category][c.tier]) out[c.category][c.tier] = [];
+    out[c.category][c.tier].push(c.name);
+  }
+  return out;
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,20 @@
+import { writable } from 'svelte/store';
+import { get, set, del } from 'idb-keyval';
+
+export interface User {
+  username: string;
+}
+
+export const user = writable<User | null>(null);
+
+get<User>('user').then((value) => {
+  if (value) user.set(value);
+});
+
+user.subscribe((value) => {
+  if (value) {
+    set('user', value);
+  } else {
+    del('user');
+  }
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,50 @@
 <script lang="ts">
-	import favicon from '$lib/assets/favicon.svg';
-
-	let { children } = $props();
+  import { user } from '$lib/store';
+  let { children } = $props();
 </script>
 
 <svelte:head>
-	<link rel="icon" href={favicon} />
+  <style>
+    :global(body) {
+      background: #111;
+      color: #eee;
+      margin: 0;
+      font-family: system-ui, sans-serif;
+    }
+    nav {
+      background: #222;
+      padding: 1rem;
+      display: flex;
+      gap: 1rem;
+    }
+    a {
+      color: #9cf;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    main {
+      padding: 1rem;
+    }
+  </style>
 </svelte:head>
 
-{@render children?.()}
+<nav>
+  <a href="/">Home</a>
+  <a href="/characters">Characters</a>
+  <a href="/lightcones">Lightcones</a>
+  <a href="/tier">Tier List</a>
+  {#if $user}
+    {#if $user.username === 'master'}
+      <a href="/admin">Admin</a>
+    {/if}
+    <a href="/login">Logout</a>
+  {:else}
+    <a href="/login">Login</a>
+  {/if}
+</nav>
+
+<main>
+  {@render children?.()}
+</main>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,2 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<h1>Prydwen-like Codex</h1>
+<p>This demo showcases a sleek dark theme with character and lightcone codex, tier list and admin tools.</p>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { user } from '$lib/store';
+  import { addCharacter, addLightcone } from '$lib/data';
+  let charName = '';
+  let charCategory = 'DPS';
+  let charTier = 'T0';
+  let coneName = '';
+  let coneRarity = '5';
+
+  async function addChar() {
+    await addCharacter({ name: charName, category: charCategory, tier: charTier });
+    charName = '';
+  }
+
+  async function addCone() {
+    await addLightcone({ name: coneName, rarity: coneRarity });
+    coneName = '';
+  }
+</script>
+
+{#if $user && $user.username === 'master'}
+  <h1>Admin Panel</h1>
+  <h2>Add Character</h2>
+  <input placeholder="name" bind:value={charName} />
+  <select bind:value={charCategory}>
+    <option>DPS</option>
+    <option>Support DPS</option>
+    <option>Amplifier</option>
+    <option>Sustain</option>
+  </select>
+  <select bind:value={charTier}>
+    <option>T0</option>
+    <option>T0.5</option>
+    <option>T1</option>
+    <option>T2</option>
+    <option>T3</option>
+    <option>T4</option>
+    <option>T5</option>
+  </select>
+  <button on:click={addChar}>Add</button>
+
+  <h2>Add Lightcone</h2>
+  <input placeholder="name" bind:value={coneName} />
+  <select bind:value={coneRarity}>
+    <option>5</option>
+    <option>4</option>
+    <option>3</option>
+  </select>
+  <button on:click={addCone}>Add</button>
+{:else}
+  <p>Not authorized.</p>
+{/if}

--- a/src/routes/characters/+page.svelte
+++ b/src/routes/characters/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getCharacters, type Character } from '$lib/data';
+  let characters: Character[] = [];
+  onMount(async () => {
+    characters = await getCharacters();
+  });
+</script>
+
+<h1>Character Codex</h1>
+{#if characters.length === 0}
+  <p>No characters yet.</p>
+{:else}
+  <ul>
+    {#each characters as c}
+      <li>{c.name} - {c.category} - {c.tier}</li>
+    {/each}
+  </ul>
+{/if}

--- a/src/routes/lightcones/+page.svelte
+++ b/src/routes/lightcones/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getLightcones, type Lightcone } from '$lib/data';
+  let cones: Lightcone[] = [];
+  onMount(async () => {
+    cones = await getLightcones();
+  });
+</script>
+
+<h1>Lightcone Codex</h1>
+{#if cones.length === 0}
+  <p>No lightcones yet.</p>
+{:else}
+  <ul>
+    {#each cones as c}
+      <li>{c.name} - {c.rarity}★</li>
+    {/each}
+  </ul>
+{/if}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { user } from '$lib/store';
+  import { get, set } from 'idb-keyval';
+  let username = '';
+  let password = '';
+  let isNew = false;
+  let message = '';
+
+  async function submit() {
+    const accounts = (await get<Record<string, string>>('accounts')) ?? {};
+    if (isNew) {
+      accounts[username] = password;
+      await set('accounts', accounts);
+      message = 'Account created.';
+      isNew = false;
+      return;
+    }
+    if ((accounts[username] && accounts[username] === password) || (username === 'master' && password === 'master')) {
+      $user = { username };
+      message = 'Logged in.';
+    } else {
+      message = 'Invalid credentials.';
+    }
+  }
+
+  function logout() {
+    user.set(null);
+  }
+</script>
+
+{#if $user}
+  <h1>Hello {$user.username}</h1>
+  <button on:click={logout}>Logout</button>
+{:else}
+  <h1>Login</h1>
+  <form on:submit|preventDefault={submit}>
+    <input placeholder="username" bind:value={username} />
+    <input placeholder="password" type="password" bind:value={password} />
+    <label><input type="checkbox" bind:checked={isNew}/> register</label>
+    <button type="submit">Submit</button>
+  </form>
+  <p>{message}</p>
+{/if}

--- a/src/routes/tier/+page.svelte
+++ b/src/routes/tier/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getTiered } from '$lib/data';
+  let tiers: Record<string, Record<string, string[]>> = {};
+  onMount(async () => {
+    tiers = await getTiered();
+  });
+</script>
+
+<h1>Tier List</h1>
+{#each Object.entries(tiers) as [cat, t]}
+  <h2>{cat}</h2>
+  {#each Object.entries(t) as [tier, list]}
+    {#if list.length}
+      <h3>{tier}</h3>
+      <ul>
+        {#each list as name}
+          <li>{name}</li>
+        {/each}
+      </ul>
+    {/if}
+  {/each}
+{/each}


### PR DESCRIPTION
## Summary
- implement dark themed layout with navigation
- add character codex, lightcone codex, tier list and admin panel
- include IndexedDB-backed login and data stores

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6898bcfbc68c83299c758e4afeb09cd0