### PR TITLE
fix: lazy load idb-keyval in browser

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,4 @@
-import { get, set } from 'idb-keyval';
+import { browser } from '$app/environment';
 
 export interface Character {
   name: string;
@@ -12,21 +12,29 @@ export interface Lightcone {
 }
 
 export async function getCharacters(): Promise<Character[]> {
+  if (!browser) return [];
+  const { get } = await import('idb-keyval');
   return (await get<Character[]>('characters')) ?? [];
 }
 
 export async function addCharacter(c: Character) {
-  const list = await getCharacters();
+  if (!browser) return;
+  const { get, set } = await import('idb-keyval');
+  const list = (await get<Character[]>('characters')) ?? [];
   list.push(c);
   await set('characters', list);
 }
 
 export async function getLightcones(): Promise<Lightcone[]> {
+  if (!browser) return [];
+  const { get } = await import('idb-keyval');
   return (await get<Lightcone[]>('lightcones')) ?? [];
 }
 
 export async function addLightcone(c: Lightcone) {
-  const list = await getLightcones();
+  if (!browser) return;
+  const { get, set } = await import('idb-keyval');
+  const list = (await get<Lightcone[]>('lightcones')) ?? [];
   list.push(c);
   await set('lightcones', list);
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import { get, set, del } from 'idb-keyval';
+import { browser } from '$app/environment';
 
 export interface User {
   username: string;
@@ -7,14 +7,18 @@ export interface User {
 
 export const user = writable<User | null>(null);
 
-get<User>('user').then((value) => {
-  if (value) user.set(value);
-});
+if (browser) {
+  import('idb-keyval').then(({ get, set, del }) => {
+    get<User>('user').then((value) => {
+      if (value) user.set(value);
+    });
 
-user.subscribe((value) => {
-  if (value) {
-    set('user', value);
-  } else {
-    del('user');
-  }
-});
+    user.subscribe((value) => {
+      if (value) {
+        set('user', value);
+      } else {
+        del('user');
+      }
+    });
+  });
+}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { user } from '$lib/store';
-  import { get, set } from 'idb-keyval';
+  import { browser } from '$app/environment';
   let username = '';
   let password = '';
   let isNew = false;
   let message = '';
 
   async function submit() {
+    if (!browser) return;
+    const { get, set } = await import('idb-keyval');
     const accounts = (await get<Record<string, string>>('accounts')) ?? {};
     if (isNew) {
       accounts[username] = password;


### PR DESCRIPTION
## Summary
- dynamically import `idb-keyval` in data helpers and login page to avoid SSR resolution errors
- guard IndexedDB access behind browser checks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898c067224483298da8faead6913562