### PR TITLE
feat: polish dark theme and add default admin

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,4 @@
-import { get, set } from 'idb-keyval';
+import { browser } from '$app/environment';
 
 export interface Character {
   name: string;
@@ -12,21 +12,29 @@ export interface Lightcone {
 }
 
 export async function getCharacters(): Promise<Character[]> {
+  if (!browser) return [];
+  const { get } = await import('idb-keyval');
   return (await get<Character[]>('characters')) ?? [];
 }
 
 export async function addCharacter(c: Character) {
-  const list = await getCharacters();
+  if (!browser) return;
+  const { get, set } = await import('idb-keyval');
+  const list = (await get<Character[]>('characters')) ?? [];
   list.push(c);
   await set('characters', list);
 }
 
 export async function getLightcones(): Promise<Lightcone[]> {
+  if (!browser) return [];
+  const { get } = await import('idb-keyval');
   return (await get<Lightcone[]>('lightcones')) ?? [];
 }
 
 export async function addLightcone(c: Lightcone) {
-  const list = await getLightcones();
+  if (!browser) return;
+  const { get, set } = await import('idb-keyval');
+  const list = (await get<Lightcone[]>('lightcones')) ?? [];
   list.push(c);
   await set('lightcones', list);
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import { get, set, del } from 'idb-keyval';
+import { browser } from '$app/environment';
 
 export interface User {
   username: string;
@@ -7,14 +7,18 @@ export interface User {
 
 export const user = writable<User | null>(null);
 
-get<User>('user').then((value) => {
-  if (value) user.set(value);
-});
+if (browser) {
+  import('idb-keyval').then(({ get, set, del }) => {
+    get<User>('user').then((value) => {
+      if (value) user.set(value);
+    });
 
-user.subscribe((value) => {
-  if (value) {
-    set('user', value);
-  } else {
-    del('user');
-  }
-});
+    user.subscribe((value) => {
+      if (value) {
+        set('user', value);
+      } else {
+        del('user');
+      }
+    });
+  });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,26 +6,63 @@
 <svelte:head>
   <style>
     :global(body) {
-      background: #111;
-      color: #eee;
+      background: #0d0d0d;
+      color: #f5f5f5;
       margin: 0;
       font-family: system-ui, sans-serif;
+      transition: background 0.3s, color 0.3s;
     }
     nav {
-      background: #222;
-      padding: 1rem;
+      background: #181818;
+      padding: 1rem 2rem;
       display: flex;
       gap: 1rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+      animation: slideDown 0.4s ease;
     }
     a {
-      color: #9cf;
+      color: #9cc9ff;
       text-decoration: none;
+      transition: color 0.2s;
     }
     a:hover {
-      text-decoration: underline;
+      color: #cfe8ff;
     }
     main {
-      padding: 1rem;
+      padding: 2rem;
+      animation: fadeIn 0.4s ease;
+    }
+    :global(input, select, button) {
+      background: #1f1f1f;
+      border: 1px solid #333;
+      border-radius: 4px;
+      padding: 0.5rem;
+      color: #f5f5f5;
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    :global(input:focus, select:focus, button:hover) {
+      border-color: #555;
+    }
+    :global(button:hover) {
+      transform: translateY(-2px);
+    }
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+    @keyframes slideDown {
+      from {
+        opacity: 0;
+        transform: translateY(-10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
     }
   </style>
 </svelte:head>
@@ -36,7 +73,7 @@
   <a href="/lightcones">Lightcones</a>
   <a href="/tier">Tier List</a>
   {#if $user}
-    {#if $user.username === 'master'}
+    {#if $user.username === 'admin'}
       <a href="/admin">Admin</a>
     {/if}
     <a href="/login">Logout</a>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -18,7 +18,7 @@
   }
 </script>
 
-{#if $user && $user.username === 'master'}
+{#if $user && $user.username === 'admin'}
   <h1>Admin Panel</h1>
   <h2>Add Character</h2>
   <input placeholder="name" bind:value={charName} />

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,12 +1,26 @@
 <script lang="ts">
   import { user } from '$lib/store';
-  import { get, set } from 'idb-keyval';
+  import { browser } from '$app/environment';
   let username = '';
   let password = '';
   let isNew = false;
   let message = '';
 
+  if (browser) {
+    import('idb-keyval').then(({ get, set }) => {
+      get<Record<string, string>>('accounts').then((accounts) => {
+        accounts = accounts ?? {};
+        if (!accounts.admin) {
+          accounts.admin = 'admin';
+          set('accounts', accounts);
+        }
+      });
+    });
+  }
+
   async function submit() {
+    if (!browser) return;
+    const { get, set } = await import('idb-keyval');
     const accounts = (await get<Record<string, string>>('accounts')) ?? {};
     if (isNew) {
       accounts[username] = password;
@@ -15,7 +29,7 @@
       isNew = false;
       return;
     }
-    if ((accounts[username] && accounts[username] === password) || (username === 'master' && password === 'master')) {
+    if (accounts[username] && accounts[username] === password) {
       $user = { username };
       message = 'Logged in.';
     } else {
@@ -41,3 +55,28 @@
   </form>
   <p>{message}</p>
 {/if}
+
+<style>
+  h1,
+  p {
+    text-align: center;
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 320px;
+    margin: 2rem auto;
+    animation: fadeIn 0.5s ease;
+  }
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- dynamically import `idb-keyval` in data helpers and login page to avoid SSR resolution errors
- apply modern dark theme with animated navigation and forms
- initialize a default `admin`/`admin` account and restrict admin tools to that user

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898c067224483298da8faead6913562