### PR TITLE
feat: polish dark theme and add default admin

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,11 +1,24 @@
 <!doctype html>
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%sveltekit.head%
-	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-	</body>
+<html lang="en" data-theme="dark">
+        <head>
+                <meta charset="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+                <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+                <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css" />
+                %sveltekit.head%
+                <style>
+                        html,
+                        body {
+                                margin: 0;
+                                font-family: 'Roboto', system-ui, sans-serif;
+                                -webkit-font-smoothing: antialiased;
+                                -moz-osx-font-smoothing: grayscale;
+                        }
+                </style>
+        </head>
+        <body data-sveltekit-preload-data="hover">
+                <div style="display: contents">%sveltekit.body%</div>
+        </body>
 </html>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,4 @@
-import { get, set } from 'idb-keyval';
+import { browser } from '$app/environment';
 
 export interface Character {
   name: string;
@@ -12,21 +12,29 @@ export interface Lightcone {
 }
 
 export async function getCharacters(): Promise<Character[]> {
+  if (!browser) return [];
+  const { get } = await import('idb-keyval');
   return (await get<Character[]>('characters')) ?? [];
 }
 
 export async function addCharacter(c: Character) {
-  const list = await getCharacters();
+  if (!browser) return;
+  const { get, set } = await import('idb-keyval');
+  const list = (await get<Character[]>('characters')) ?? [];
   list.push(c);
   await set('characters', list);
 }
 
 export async function getLightcones(): Promise<Lightcone[]> {
+  if (!browser) return [];
+  const { get } = await import('idb-keyval');
   return (await get<Lightcone[]>('lightcones')) ?? [];
 }
 
 export async function addLightcone(c: Lightcone) {
-  const list = await getLightcones();
+  if (!browser) return;
+  const { get, set } = await import('idb-keyval');
+  const list = (await get<Lightcone[]>('lightcones')) ?? [];
   list.push(c);
   await set('lightcones', list);
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,5 +1,5 @@
 import { writable } from 'svelte/store';
-import { get, set, del } from 'idb-keyval';
+import { browser } from '$app/environment';
 
 export interface User {
   username: string;
@@ -7,14 +7,18 @@ export interface User {
 
 export const user = writable<User | null>(null);
 
-get<User>('user').then((value) => {
-  if (value) user.set(value);
-});
+if (browser) {
+  import('idb-keyval').then(({ get, set, del }) => {
+    get<User>('user').then((value) => {
+      if (value) user.set(value);
+    });
 
-user.subscribe((value) => {
-  if (value) {
-    set('user', value);
-  } else {
-    del('user');
-  }
-});
+    user.subscribe((value) => {
+      if (value) {
+        set('user', value);
+      } else {
+        del('user');
+      }
+    });
+  });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,47 +1,62 @@
 <script lang="ts">
   import { user } from '$lib/store';
+  import { goto } from '$app/navigation';
   let { children } = $props();
 </script>
 
 <svelte:head>
   <style>
-    :global(body) {
-      background: #111;
-      color: #eee;
+    :global(html, body) {
       margin: 0;
-      font-family: system-ui, sans-serif;
+      font-family: 'Roboto', system-ui, sans-serif;
+      transition: background 0.3s, color 0.3s;
     }
     nav {
-      background: #222;
-      padding: 1rem;
+      padding: 1rem 2rem;
       display: flex;
-      gap: 1rem;
+      gap: 0.5rem;
+      animation: slideDown 0.4s ease;
     }
-    a {
-      color: #9cf;
-      text-decoration: none;
-    }
-    a:hover {
-      text-decoration: underline;
+    nav button {
+      border-radius: 0.5rem;
     }
     main {
-      padding: 1rem;
+      padding: 2rem;
+      animation: fadeIn 0.4s ease;
+    }
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+    @keyframes slideDown {
+      from {
+        opacity: 0;
+        transform: translateY(-10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
     }
   </style>
 </svelte:head>
 
 <nav>
-  <a href="/">Home</a>
-  <a href="/characters">Characters</a>
-  <a href="/lightcones">Lightcones</a>
-  <a href="/tier">Tier List</a>
+  <button type="button" onclick={() => goto('/')}>Home</button>
+  <button type="button" onclick={() => goto('/characters')}>Characters</button>
+  <button type="button" onclick={() => goto('/lightcones')}>Lightcones</button>
+  <button type="button" onclick={() => goto('/tier')}>Tier List</button>
   {#if $user}
-    {#if $user.username === 'master'}
-      <a href="/admin">Admin</a>
+    {#if $user.username === 'admin'}
+      <button type="button" onclick={() => goto('/admin')}>Admin</button>
     {/if}
-    <a href="/login">Logout</a>
+    <button type="button" onclick={() => goto('/login')}>Logout</button>
   {:else}
-    <a href="/login">Login</a>
+    <button type="button" onclick={() => goto('/login')}>Login</button>
   {/if}
 </nav>
 

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -18,7 +18,7 @@
   }
 </script>
 
-{#if $user && $user.username === 'master'}
+{#if $user && $user.username === 'admin'}
   <h1>Admin Panel</h1>
   <h2>Add Character</h2>
   <input placeholder="name" bind:value={charName} />

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,12 +1,26 @@
 <script lang="ts">
   import { user } from '$lib/store';
-  import { get, set } from 'idb-keyval';
+  import { browser } from '$app/environment';
   let username = '';
   let password = '';
   let isNew = false;
   let message = '';
 
+  if (browser) {
+    import('idb-keyval').then(({ get, set }) => {
+      get<Record<string, string>>('accounts').then((accounts) => {
+        accounts = accounts ?? {};
+        if (!accounts.admin) {
+          accounts.admin = 'admin';
+          set('accounts', accounts);
+        }
+      });
+    });
+  }
+
   async function submit() {
+    if (!browser) return;
+    const { get, set } = await import('idb-keyval');
     const accounts = (await get<Record<string, string>>('accounts')) ?? {};
     if (isNew) {
       accounts[username] = password;
@@ -15,7 +29,7 @@
       isNew = false;
       return;
     }
-    if ((accounts[username] && accounts[username] === password) || (username === 'master' && password === 'master')) {
+    if (accounts[username] && accounts[username] === password) {
       $user = { username };
       message = 'Logged in.';
     } else {
@@ -41,3 +55,28 @@
   </form>
   <p>{message}</p>
 {/if}
+
+<style>
+  h1,
+  p {
+    text-align: center;
+  }
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 320px;
+    margin: 2rem auto;
+    animation: fadeIn 0.5s ease;
+  }
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- switch to the Roboto font and load Pico.css for a sleeker default style
- convert top navigation links into rounded buttons powered by `goto`
- retain modern dark theme with animated transitions across pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898c067224483298da8faead6913562